### PR TITLE
Refactor exp corrections flow

### DIFF
--- a/src/redactionAssitant/main.py
+++ b/src/redactionAssitant/main.py
@@ -25,14 +25,13 @@ def process_flow() -> None:
     proc = Processor(cfg, cfg.API_KEY)
 
     # 3) Corregir y obtener feedback
-    new_cps, resume_fb = proc.cps_corregidas(hus, cps)
-    new_exp = proc.exp_corregidos(hus, cps, exp)
-    #sume_fb = proc.resume_feedback(fb_cps, fb_exp)
-    new_exp, exp_fb = proc.exp_corregidos(hus, new_cps, exp)
-    
-    logging.info("Feedback resumido:\n%s", resume_fb)
+    new_cps, cps_feedback = proc.cps_corregidas(hus, cps)
+    new_exp, exp_feedback = proc.exp_corregidos(hus, new_cps, exp)
 
-    resume_fb += "\n\n" + exp_fb
+    feedback_parts = [part for part in (cps_feedback, exp_feedback) if part]
+    resume_fb = "\n\n".join(feedback_parts)
+
+    logging.info("Feedback resumido:\n%s", resume_fb)
     # 4) Guardar salidas
     cps_out, exp_out, fb_out = cfg.all_output_paths()
     save_data(new_cps, new_exp, resume_fb, cps_out, exp_out, fb_out)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,6 +45,7 @@ class TestMain:
             Path("exp_out.txt"),
             Path("fb_out.txt")
         )
+        mock_logging.info.assert_called_with("Feedback resumido:\n%s", "CPS feedback\n\nEXP feedback")
 
     @patch('src.redactionAssitant.main.Config')
     @patch('src.redactionAssitant.main.get_data')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,11 +24,7 @@ class TestMain:
 
         mock_processor = MagicMock()
         mock_processor.cps_corregidas.return_value = ("corrected CPS", "CPS feedback")
-        # exp_corregidos is called twice in the actual code
-        mock_processor.exp_corregidos.side_effect = [
-            ("intermediate EXP", "intermediate feedback"),  # First call
-            ("corrected EXP", "EXP feedback")  # Second call
-        ]
+        mock_processor.exp_corregidos.return_value = ("corrected EXP", "EXP feedback")
         mock_processor_class.return_value = mock_processor
 
         # Import and call the function
@@ -40,11 +36,15 @@ class TestMain:
         mock_get_data.assert_called_once_with(mock_config)
         mock_processor_class.assert_called_once_with(mock_config, mock_config.API_KEY)
         mock_processor.cps_corregidas.assert_called_once_with("HU text", "CPS text")
-        # exp_corregidos is called twice
-        assert mock_processor.exp_corregidos.call_count == 2
-        mock_processor.exp_corregidos.assert_any_call("HU text", "CPS text", "EXP text")
-        mock_processor.exp_corregidos.assert_any_call("HU text", "corrected CPS", "EXP text")
-        mock_save_data.assert_called_once_with("corrected CPS", "corrected EXP", "CPS feedback\n\nEXP feedback", Path("cps_out.txt"), Path("exp_out.txt"), Path("fb_out.txt"))
+        mock_processor.exp_corregidos.assert_called_once_with("HU text", "corrected CPS", "EXP text")
+        mock_save_data.assert_called_once_with(
+            "corrected CPS",
+            "corrected EXP",
+            "CPS feedback\n\nEXP feedback",
+            Path("cps_out.txt"),
+            Path("exp_out.txt"),
+            Path("fb_out.txt")
+        )
 
     @patch('src.redactionAssitant.main.Config')
     @patch('src.redactionAssitant.main.get_data')


### PR DESCRIPTION
## Summary
- update `process_flow` to call `exp_corregidos` once with corrected CPS and combine returned feedback segments
- align unit tests with the new flow and feedback concatenation expectations

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ca3ac24718832e9cb890bd1c9f324e

## Summary by Sourcery

Refactor the main correction flow to call exp_corregidos only once and unify feedback concatenation, and update unit tests to match the new behavior

Enhancements:
- Call exp_corregidos a single time using corrected CPS output
- Combine CPS and EXP feedback into a single resume_fb string by filtering and joining with double newlines

Tests:
- Update unit tests to expect one exp_corregidos invocation and validate concatenated feedback in save_data call