### PR TITLE
update dev

### DIFF
--- a/planner.md
+++ b/planner.md
@@ -1,10 +1,7 @@
-En corto: si no tienes habilitado el import en tu GitHub, lo más rápido es levantar **issues manuales** con copy-paste del contenido. Te lo dejo ya formateado para que copies cada uno como nuevo issue.
-
----
 
 ## 🏁 Sprint 1 — Calidad y Estabilidad (prioridad máxima)
 
-### Issue 1: Tests unitarios base (processor & builder) ≥80%
+### Issue 1: Tests unitarios base (processor & builder) ≥80% [ HECHO]
 
 **Objetivo:** Cobertura mínima del 80% en módulos `processor` y `builder` con `pytest`.
 **Criterios de aceptación:**
@@ -102,8 +99,51 @@ En corto: si no tienes habilitado el import en tu GitHub, lo más rápido es lev
 * **Versionado semántico + releases** (`priority:low`, `area:release`, 2-3 días)
 * **Guías de contribución + templates** (`priority:low`, `area:community`, 3-4 días)
 
----
 
-👉 Mi recomendación: crea los **3 issues de Sprint 1 hoy mismo** (tests, CI, logging) y añádeles milestone “Sprint 1 — Calidad”. Son los que te darán visibilidad inmediata.
 
-¿Quieres que te prepare también un **template de issue** (`.github/ISSUE_TEMPLATE.md`) con estos campos (Objetivo, Criterios de aceptación, DoD, Labels)?
+Aspectos positivos
+Hay una suite de pruebas amplia que cubre los módulos principales (main, builder, processor, config y utilidades) con escenarios de éxito y de error, lo que facilita detectar regresiones sin depender de llamadas reales al LLM.
+
+Los módulos productivos están bien documentados y usan logging para trazar el flujo, algo clave cuando se orquesta procesamiento concurrente y dependencias externas.
+
+El README y el planner ofrecen una visión clara de arquitectura, roadmap y backlog priorizado, lo que facilita coordinar esfuerzos futuros.
+
+Problemas y oportunidades de mejora
+process_flow invoca Processor.exp_corregidos dos veces: primero con los CPS originales y luego con los corregidos, descartando el primer resultado. Esto duplica las llamadas al LLM, incrementa coste/latencia y mezcla feedback parcial antes de guardarlo.
+
+Tarea sugerida
+Invocar exp_corregidos una sola vez con CPS corregidos
+
+Iniciar tarea
+El pipeline de expected results usa cps.splitlines()/exp.splitlines() sin limpiar vacíos, por lo que rechaza pares válidos si hay líneas en blanco, y además envía listas completas a Builder.corregir_expect_result, cuyo prompt espera un texto, de modo que hoy el modelo recibe representaciones con corchetes y comillas.
+
+Tarea sugerida
+Sanear batches de expected results y ajustar el prompt
+
+Iniciar tarea
+La configuración ignora la variable HU_CODE descrita en el README y fija el prefijo a USRNM, lo que impide adaptar el sistema a diferentes nomenclaturas sin tocar código.
+
+Tarea sugerida
+Leer HU_CODE desde configuración
+
+Iniciar tarea
+El fichero requirements.txt está poblado con paquetes de entornos Conda específicos (file:///croot/...), muchos sin relación con el proyecto, lo que dificulta replicar el entorno con pip y aumenta el riesgo de vulnerabilidades no controladas.
+
+Tarea sugerida
+Depurar y normalizar requirements.txt
+
+Iniciar tarea
+Funcionalidades pendientes
+Quedan por abordar las iniciativas del roadmap (API web, soporte DOCX/PDF, base de datos, integraciones con herramientas de gestión, internacionalización, etc.), que todavía no tienen implementación en el código actual.
+
+El planner ya prioriza sprints futuros (CI/CD con linting, logging estructurado, fallback de proveedor LLM, API mínima) y puede servir como guía para ampliar capacidades una vez estabilizados los bugs inmediatos.
+
+Prioridades recomendadas
+Corregir el flujo de expected results (doble llamada y sanitización de batches), porque impacta directamente en costes y calidad del texto devuelto por el LLM.
+
+Ajustar la configuración (HU_CODE) para respetar parámetros de entorno y permitir escalar a distintos proyectos sin tocar código.
+
+Limpiar requirements.txt para garantizar instalaciones reproducibles y seguras.
+
+Una vez estabilizado lo anterior, retomar las tareas de observabilidad y resiliencia del planner (CI/CD, logging estructurado, fallback de proveedor) antes de atacar nuevas funcionalidades como la API.
+

--- a/src/redactionAssitant/main.py
+++ b/src/redactionAssitant/main.py
@@ -25,14 +25,13 @@ def process_flow() -> None:
     proc = Processor(cfg, cfg.API_KEY)
 
     # 3) Corregir y obtener feedback
-    new_cps, resume_fb = proc.cps_corregidas(hus, cps)
-    new_exp = proc.exp_corregidos(hus, cps, exp)
-    #sume_fb = proc.resume_feedback(fb_cps, fb_exp)
-    new_exp, exp_fb = proc.exp_corregidos(hus, new_cps, exp)
-    
-    logging.info("Feedback resumido:\n%s", resume_fb)
+    new_cps, cps_feedback = proc.cps_corregidas(hus, cps)
+    new_exp, exp_feedback = proc.exp_corregidos(hus, new_cps, exp)
 
-    resume_fb += "\n\n" + exp_fb
+    feedback_parts = [part for part in (cps_feedback, exp_feedback) if part]
+    resume_fb = "\n\n".join(feedback_parts)
+
+    logging.info("Feedback resumido:\n%s", resume_fb)
     # 4) Guardar salidas
     cps_out, exp_out, fb_out = cfg.all_output_paths()
     save_data(new_cps, new_exp, resume_fb, cps_out, exp_out, fb_out)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,6 +45,7 @@ class TestMain:
             Path("exp_out.txt"),
             Path("fb_out.txt")
         )
+        mock_logging.info.assert_called_with("Feedback resumido:\n%s", "CPS feedback\n\nEXP feedback")
 
     @patch('src.redactionAssitant.main.Config')
     @patch('src.redactionAssitant.main.get_data')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,11 +24,7 @@ class TestMain:
 
         mock_processor = MagicMock()
         mock_processor.cps_corregidas.return_value = ("corrected CPS", "CPS feedback")
-        # exp_corregidos is called twice in the actual code
-        mock_processor.exp_corregidos.side_effect = [
-            ("intermediate EXP", "intermediate feedback"),  # First call
-            ("corrected EXP", "EXP feedback")  # Second call
-        ]
+        mock_processor.exp_corregidos.return_value = ("corrected EXP", "EXP feedback")
         mock_processor_class.return_value = mock_processor
 
         # Import and call the function
@@ -40,11 +36,15 @@ class TestMain:
         mock_get_data.assert_called_once_with(mock_config)
         mock_processor_class.assert_called_once_with(mock_config, mock_config.API_KEY)
         mock_processor.cps_corregidas.assert_called_once_with("HU text", "CPS text")
-        # exp_corregidos is called twice
-        assert mock_processor.exp_corregidos.call_count == 2
-        mock_processor.exp_corregidos.assert_any_call("HU text", "CPS text", "EXP text")
-        mock_processor.exp_corregidos.assert_any_call("HU text", "corrected CPS", "EXP text")
-        mock_save_data.assert_called_once_with("corrected CPS", "corrected EXP", "CPS feedback\n\nEXP feedback", Path("cps_out.txt"), Path("exp_out.txt"), Path("fb_out.txt"))
+        mock_processor.exp_corregidos.assert_called_once_with("HU text", "corrected CPS", "EXP text")
+        mock_save_data.assert_called_once_with(
+            "corrected CPS",
+            "corrected EXP",
+            "CPS feedback\n\nEXP feedback",
+            Path("cps_out.txt"),
+            Path("exp_out.txt"),
+            Path("fb_out.txt")
+        )
 
     @patch('src.redactionAssitant.main.Config')
     @patch('src.redactionAssitant.main.get_data')


### PR DESCRIPTION
## Summary by Sourcery

Simplify process_flow, align tests, and enrich planner documentation

Enhancements:
- Refactor process_flow to invoke exp_corregidos only once, filter empty feedback parts, and combine CPS/EXP feedback for logging.
- Replace side_effect in tests to expect a single exp_corregidos call and add verification of the combined feedback log.

Documentation:
- Update planner.md to mark unit tests sprint as done and add positive aspects, identified issues, suggested tasks, pending functionalities, and recommended priorities for upcoming work.

Tests:
- Adjust test_process_flow_success to reflect the single exp_corregidos call, validate arguments and the new logging behavior.