### PR TITLE
Improve expected results batching and tests

### DIFF
--- a/src/redactionAssitant/builder.py
+++ b/src/redactionAssitant/builder.py
@@ -1,6 +1,6 @@
 from openai import OpenAI  
 import logging
-from typing import List
+from typing import List, Union
 
 class Builder:
     """Constructor de casos de prueba, expect results y correcciones ortográficas."""
@@ -57,7 +57,9 @@ class Builder:
             self.logger.error("Error al obtener feedback: %s", e)
             return f"Error: {str(e)}"
 
-    def corregir_expect_result(self, cps_with_expectResult: str):
+    def corregir_expect_result(self, cps_with_expectResult: Union[str, List[str]]):
+        if isinstance(cps_with_expectResult, list):
+            cps_with_expectResult = "\n".join(cps_with_expectResult)
         try:
             response = self.client.chat.completions.create(
                 model=self.model,

--- a/src/redactionAssitant/builder.py
+++ b/src/redactionAssitant/builder.py
@@ -59,7 +59,9 @@ class Builder:
 
     def corregir_expect_result(self, cps_with_expectResult: Union[str, List[str]]):
         if isinstance(cps_with_expectResult, list):
-            cps_with_expectResult = "\n".join(cps_with_expectResult)
+            # Sanitize each element to remove embedded newlines
+            sanitized_elements = [elem.replace('\n', ' ') if isinstance(elem, str) else str(elem) for elem in cps_with_expectResult]
+            cps_with_expectResult = "\n".join(sanitized_elements)
         try:
             response = self.client.chat.completions.create(
                 model=self.model,

--- a/src/redactionAssitant/processor.py
+++ b/src/redactionAssitant/processor.py
@@ -1,6 +1,6 @@
 import logging
 from src.redactionAssitant import builder as b
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 import re 
 from openai import OpenAI  
 
@@ -164,26 +164,28 @@ class Processor:
         if safe_quit:
             return "", ""
 
+        cps_list = preprocess_exp_or_cps(cps)
+        exp_list = preprocess_exp_or_cps(exp)
+
         # Procesar en batches
-        if len(cps.splitlines()) != len(exp.splitlines()):
+        if len(cps_list) != len(exp_list):
             self.logger.warning("Los casos de prueba y resultados esperados no tienen la misma longitud.")
-            self.logger.warning("número de casos de prueba: %d", len(cps.splitlines()))
-            self.logger.warning("número de resultados esperados: %d", len(exp.splitlines()))
+            self.logger.warning("número de casos de prueba: %d", len(cps_list))
+            self.logger.warning("número de resultados esperados: %d", len(exp_list))
             self.logger.warning("CPS: %s", cps)
             self.logger.warning("EXP: %s", exp)
             return "",""
-        else:
-            exp_list = cps_with_exp(cps, exp)
 
-        if not exp_list:
+        if not cps_list:
             return "",""
-        
 
-        batches = [exp_list[i : i + self.batch_size] for i in range(0, len(exp_list), self.batch_size)]
+        clean_pairs = [f"{cp} | {ex}" for cp, ex in zip(cps_list, exp_list)]
+
+        batches = [clean_pairs[i : i + self.batch_size] for i in range(0, len(clean_pairs), self.batch_size)]
 
         results = []
         with ThreadPoolExecutor(max_workers=4) as executor:
-            for batch_out in executor.map(self.builder.corregir_expect_result, batches):
+            for batch_out in executor.map(lambda batch: self.builder.corregir_expect_result("\n".join(batch)), batches):
                 results.extend(batch_out.splitlines())
 
         sep_obs = "OBS"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -157,6 +157,20 @@ class TestBuilder:
         assert "OBS:" in user_prompt2
         assert "tiempo presente" in user_prompt2
 
+    def test_corregir_expect_result_accepts_list_without_python_syntax(self, builder, mock_client):
+        """Ensure list inputs are transformed into clean multiline prompts"""
+        data = ["CP1 | Exp1", "CP2 | Exp2"]
+
+        builder.corregir_expect_result(data)
+
+        call_args = mock_client.chat.completions.create.call_args
+        user_prompt = call_args[1]["messages"][1]["content"]
+
+        assert "[" not in user_prompt and "]" not in user_prompt
+        assert "CP1 | Exp1" in user_prompt
+        assert "CP2 | Exp2" in user_prompt
+        assert "CP1 | Exp1\nCP2 | Exp2" in user_prompt
+
     @pytest.mark.parametrize("method_name,expected_log_message", [
         ("corregir_ortografia", "Error al llamar a la API"),
         ("obtener_feedback", "Error al obtener feedback"),


### PR DESCRIPTION
## Summary
- ensure Processor.exp_corregidos reuses preprocessing to align CPS and EXP counts and builds clean batches joined per request
- allow Builder.corregir_expect_result to accept list inputs and normalize prompts before sending them to the LLM client
- extend processor and builder tests to cover blank lines and assert plain-text prompts without Python list syntax

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3f8b9e20832e82332527b5251c60

## Summary by Sourcery

Enhance expected results correction by reusing preprocessing to align CPS and EXP counts, ignore blank lines, and build clean "CP | EXP" batches for the LLM client; update Builder.corregir_expect_result to accept and normalize list inputs; and extend tests to cover blank-line handling and prompt formatting.

New Features:
- Allow Builder.corregir_expect_result to accept list inputs and normalize them into newline-separated strings

Enhancements:
- Refactor Processor.exp_corregidos to preprocess inputs, align line counts, ignore blank lines, format test-case/expected-result pairs, and batch requests
- Refactor batch submission in exp_corregidos to join each batch into a plain-text prompt before sending to the builder

Tests:
- Add processor tests for blank-line handling and plain-text batch prompts
- Add builder test to verify list inputs produce multiline prompts without Python list syntax
- Update mismatch-lines test to include blank-line padded inputs