### PR TITLE
Support configurable HU code fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ DS_API_KEY=tu_api_key
 HU_CODE=USRNM
 ```
 
+> Nota: si `HU_CODE` no está definida en tu entorno, el sistema utilizará `USRNM` como prefijo por defecto. Configura esta variable si necesitas personalizar el código de historia de usuario.
+
 ---
 
 ## Uso

--- a/src/redactionAssitant/config.py
+++ b/src/redactionAssitant/config.py
@@ -20,7 +20,7 @@ class Config:
             self.code_hu = default_hu_code
         else:
             raise ValueError(
-                "HU_CODE no encontrada en las variables de entorno y no se proporcionó valor por defecto"
+                f"HU_CODE no encontrada en las variables de entorno y no se proporcionó valor por defecto (default_hu_code={default_hu_code!r})"
             )
 
         # Usar Path para mejor manejo de rutas

--- a/src/redactionAssitant/config.py
+++ b/src/redactionAssitant/config.py
@@ -6,13 +6,22 @@ load_dotenv()
 
 class Config:
     """Configuración centralizada para el redactor automático."""
-    
-    def __init__(self):
+
+    def __init__(self, default_hu_code: str | None = "USRNM"):
         self.API_KEY = os.getenv("DS_API_KEY")
-        self.code_hu = "USRNM"
 
         if not self.API_KEY:
             raise ValueError("DS_API_KEY no encontrada en las variables de entorno")
+
+        hu_code = os.getenv("HU_CODE")
+        if hu_code:
+            self.code_hu = hu_code
+        elif default_hu_code is not None:
+            self.code_hu = default_hu_code
+        else:
+            raise ValueError(
+                "HU_CODE no encontrada en las variables de entorno y no se proporcionó valor por defecto"
+            )
 
         # Usar Path para mejor manejo de rutas
         self.input_dir = Path("data/raw/")


### PR DESCRIPTION
## Summary
- load the HU code from the environment with an optional fallback and raise a clear error when none is available
- extend the Config tests to parameterize HU_CODE values and validate fallback behavior
- document the default HU_CODE prefix in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4ce418c4832ea98f3744abab8b85

## Summary by Sourcery

Enable configurable HU code in the Config class with an optional fallback and clear error handling, update tests to cover the new fallback logic, and document the default HU_CODE behavior in the README.

Enhancements:
- Load HU_CODE from the environment with an optional default fallback and raise a descriptive error when neither is provided.

Documentation:
- Document the default HU_CODE fallback behavior in the README.

Tests:
- Parameterize Config tests to cover environment HU_CODE, custom fallback, default fallback, and missing fallback error cases.